### PR TITLE
Fix assistantAccount, accountList order mismatch

### DIFF
--- a/internal/app/auth/step1.go
+++ b/internal/app/auth/step1.go
@@ -326,10 +326,10 @@ func addAccounts(a *Assistant, accountList *gtk.ListBox, src secret.Driver, acco
 			continue
 		}
 
-		a.accounts = append(a.accounts, assistantAccount{
+		a.accounts = append([]assistantAccount{{
 			Account: account,
 			src:     src,
-		})
+		}}, a.accounts...)
 		accountList.Prepend(newAccountEntry(a.ctx, account))
 	}
 }


### PR DESCRIPTION
When you have multiple accounts on the login page, clicking on the first
account opens the last account.